### PR TITLE
Using broadcastedFirstTimeAt as source for date and time.

### DIFF
--- a/ohdieux/util/dateparse.py
+++ b/ohdieux/util/dateparse.py
@@ -49,16 +49,19 @@ def parse_fr_date(formatted: str) -> datetime:
 
 def infer_fr_date(item: dict) -> datetime:
     x = SafeDict(item)
-    candidates = [
-        x["media2"]["details"].value(),
-        x["title"].value(),
-        x["description"]["title"].value(),
-        x["header"]["media2"]["title"].value(),
-    ]
-    try:
-        return Stream(candidates).map(extract_tentative_date).filter(lambda x: x is not None).max()
-    except:
-        return datetime(year=2000, month=1, day=1)
+    if 'broadcastedFirstTimeAt' in item:
+        return datetime.strptime(item["broadcastedFirstTimeAt"], '%Y-%m-%dT%H:%M:%S.%fZ')
+    else:
+        candidates = [
+            x["media2"]["details"].value(),
+            x["title"].value(),
+            x["description"]["title"].value(),
+            x["header"]["media2"]["title"].value(),
+        ]
+        try:
+            return Stream(candidates).map(extract_tentative_date).filter(lambda x: x is not None).max()
+        except:
+            return datetime(year=2000, month=1, day=1)
 
 
 def extract_tentative_date(text: str) -> Optional[datetime]:


### PR DESCRIPTION
J'ai remarqué que le parsing de date était brisé et j'ai aussi remarqué dans le json qu'il y avait un champ de date.

De cette manière, ça favorise le champ qui existe déjà et si le champ est absent on garde le comportement par défaut.