### PR TITLE
Added QR code for generated URL

### DIFF
--- a/ohdieux/views/index.html
+++ b/ohdieux/views/index.html
@@ -60,7 +60,11 @@
     </div>
     <br />
     <a id="rss"> </a>
+    <p>
+      <div id="qrcode"></div>
+    </p>
   </body>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
   <script>
     document.getElementById("submit").onclick = (e) => {
       let link =
@@ -77,6 +81,8 @@
       document.getElementById("rss").href = link;
       document.getElementById("rss").innerHTML =
         document.getElementById("rss").href;
+      document.getElementById("qrcode").innerHTML = "";
+      let qrcode = new QRCode(document.getElementById("qrcode"), link);
     };
   </script>
 </html>


### PR DESCRIPTION
Hello,

I added a QR code to represent the generated URL so that it's easy to scan the URL with your phone if you loaded ohdieux on another device (e.g. your friend's phone or computer).

This adds a dependency to https://davidshimjs.github.io/qrcodejs/ but I wasn't sure if you were OK with that. It could be a ~20kb local JS file too, as there is a [minified version](https://github.com/davidshimjs/qrcodejs/blob/master/qrcode.min.js) as well.

I tested this locally and it worked fine in Safari, Chrome, and Firefox.